### PR TITLE
refactor: move home configuration to separate file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-nix build .#hmConfig.marshall.activationPackage
-./result/activate
-sudo nixos-rebuild switch --flake .#
+nixos-rebuild switch --flake .# --use-remote-sudo

--- a/flake.nix
+++ b/flake.nix
@@ -39,179 +39,21 @@
     { self
     , nixpkgs
     , home-manager
-    , nur
-    , powercord-overlay
-    , neovim-nightly-overlay
-    , vscodeInsiders
-    , theme-toggler
-    , powercord-tiktok-tts
-    , lavender-discord
-    , catppuccin
-    , flake-firefox-nightly
-    }:
+    , ...
+    } @ inputs:
     let
-      system = "x86_64-linux";
-      pkgs = import nixpkgs {
-        inherit system;
-        config.allowUnfree = true;
-      };
-      lib = nixpkgs.lib;
+      inherit (nixpkgs) lib;
     in
     {
       nixosConfigurations = {
         nix = lib.nixosSystem {
-          inherit system;
-          modules = [ ./sys/configuration.nix ];
-        };
-      };
-      hmConfig = {
-        marshall = home-manager.lib.homeManagerConfiguration {
-          inherit system pkgs;
-          username = "marshall";
-          homeDirectory = "/home/marshall";
-          stateVersion = "22.05";
-          configuration = {
-            imports = [
-              {
-                nixpkgs.overlays = [
-                  (self: super: {
-                    vscodeInsiders =
-                      vscodeInsiders.packages.${super.system}.vscodeInsiders;
-                  })
-                  powercord-overlay.overlay
-                  nur.overlay
-                  neovim-nightly-overlay.overlay
-                ];
-                nixpkgs.config.allowUnfree = true;
-              }
-
-              ({ pkgs, config, ... }: {
-                home.packages = with pkgs; [
-                  pkgs.nur.repos.marsupialgutz.draconis
-                  flake-firefox-nightly.packages.x86_64-linux.firefox-nightly-bin
-
-                  acpi
-                  acpid
-                  audacity
-                  binutils
-                  brightnessctl
-                  cargo-binutils
-                  chrome-gnome-shell
-                  cinnamon.nemo
-                  cmake
-                  dbus
-                  dbus.dev
-                  exa
-                  feh
-                  ffmpeg
-                  file
-                  gcc
-                  gh
-                  gnomeExtensions.appindicator
-                  gnomeExtensions.pop-shell
-                  gnome.gnome-tweaks
-                  gnome.seahorse
-                  gnumake
-                  gnupg
-                  gpick
-                  headsetcontrol
-                  jamesdsp
-                  jq
-                  keychain
-                  killall
-                  kitty
-                  kotatogram-desktop
-                  libnotify
-                  lua52Packages.lgi
-                  lxappearance
-                  mate.engrampa
-                  micro
-                  minecraft
-                  mpd
-                  mpv
-                  ncmpcpp
-                  neovide
-                  neovim-nightly
-                  nerdfonts
-                  nixfmt
-                  nix-prefetch-scripts
-                  nodejs
-                  noto-fonts-cjk-sans
-                  pamixer
-                  papirus-icon-theme
-                  pavucontrol
-                  playerctl
-                  polymc
-                  python
-                  python310
-                  redshift
-                  rofi
-                  rustup
-                  rust-analyzer
-                  scrot
-                  spicetify-cli
-                  spot
-                  sumneko-lua-language-server
-                  unrar
-                  unzip
-                  upower
-                  wineWowPackages.full
-                  xclip
-                  xdotool
-                  yarn
-                  zoxide
-                  zsh
-
-                  (pkgs.discord-plugged.override {
-                    plugins = [ theme-toggler powercord-tiktok-tts ];
-                    themes = [ lavender-discord catppuccin ];
-                  })
-                ];
-                programs.vscode = with pkgs; {
-                  enable = true;
-                  package = vscodeInsiders;
-                };
-
-                programs.git = {
-                  enable = true;
-                  userName = "marsupialgutz";
-                  userEmail = "mars@possums.xyz";
-                };
-
-                services.picom = {
-                  enable = true;
-                  blur = true;
-                  extraOptions = ''
-                    blur-method = "dual_kawase";
-                    strength = 15;
-                  '';
-                  experimentalBackends = true;
-
-                  shadowExclude = [ "bounding_shaped && !rounded_corners" ];
-
-                  fade = true;
-                  fadeDelta = 7;
-                  vSync = true;
-                  opacityRule = [
-                    "100:class_g   *?= 'Chromium-browser'"
-                    "100:class_g   *?= 'Firefox'"
-                    "100:class_g   *?= 'gitkraken'"
-                    "100:class_g   *?= 'emacs'"
-                    "100:class_g   ~=  'jetbrains'"
-                    "100:class_g   *?= 'slack'"
-                  ];
-                  package = pkgs.picom.overrideAttrs (o: {
-                    src = pkgs.fetchFromGitHub {
-                      repo = "picom";
-                      owner = "ibhagwan";
-                      rev = "44b4970f70d6b23759a61a2b94d9bfb4351b41b1";
-                      sha256 = "0iff4bwpc00xbjad0m000midslgx12aihs33mdvfckr75r114ylh";
-                    };
-                  });
-                };
-              })
-            ];
-          };
+          system = "x86_64-linux";
+          # Pass inputs to NixOS modules
+          specialArgs = { inherit inputs; };
+          modules = [
+            ./sys/configuration.nix
+            home-manager.nixosModule
+          ];
         };
       };
     };

--- a/home/default.nix
+++ b/home/default.nix
@@ -1,0 +1,124 @@
+{ pkgs, config, ... }: {
+  home.packages = with pkgs; [
+    pkgs.nur.repos.marsupialgutz.draconis
+    firefox-nightly-bin
+    acpi
+    acpid
+    audacity
+    binutils
+    brightnessctl
+    cargo-binutils
+    chrome-gnome-shell
+    cinnamon.nemo
+    cmake
+    dbus
+    dbus.dev
+    exa
+    feh
+    ffmpeg
+    file
+    gcc
+    gh
+    gnomeExtensions.appindicator
+    gnomeExtensions.pop-shell
+    gnome.gnome-tweaks
+    gnome.seahorse
+    gnumake
+    gnupg
+    gpick
+    headsetcontrol
+    jamesdsp
+    jq
+    keychain
+    killall
+    kitty
+    kotatogram-desktop
+    libnotify
+    lua52Packages.lgi
+    lxappearance
+    mate.engrampa
+    micro
+    minecraft
+    mpd
+    mpv
+    ncmpcpp
+    neovide
+    neovim-nightly
+    nerdfonts
+    nixfmt
+    nix-prefetch-scripts
+    nodejs
+    noto-fonts-cjk-sans
+    pamixer
+    papirus-icon-theme
+    pavucontrol
+    playerctl
+    polymc
+    python
+    python310
+    redshift
+    rofi
+    rustup
+    rust-analyzer
+    scrot
+    spicetify-cli
+    spot
+    sumneko-lua-language-server
+    unrar
+    unzip
+    upower
+    wineWowPackages.full
+    xclip
+    xdotool
+    yarn
+    zoxide
+    zsh
+
+    (pkgs.discord-plugged.override {
+      plugins = [ theme-toggler powercord-tiktok-tts ];
+      themes = [ lavender-discord catppuccin ];
+    })
+  ];
+  programs.vscode = with pkgs; {
+    enable = true;
+    package = vscodeInsiders;
+  };
+
+  programs.git = {
+    enable = true;
+    userName = "marsupialgutz";
+    userEmail = "mars@possums.xyz";
+  };
+
+  services.picom = {
+    enable = true;
+    blur = true;
+    extraOptions = ''
+      blur-method = "dual_kawase";
+      strength = 15;
+    '';
+    experimentalBackends = true;
+
+    shadowExclude = [ "bounding_shaped && !rounded_corners" ];
+
+    fade = true;
+    fadeDelta = 7;
+    vSync = true;
+    opacityRule = [
+      "100:class_g   *?= 'Chromium-browser'"
+      "100:class_g   *?= 'Firefox'"
+      "100:class_g   *?= 'gitkraken'"
+      "100:class_g   *?= 'emacs'"
+      "100:class_g   ~=  'jetbrains'"
+      "100:class_g   *?= 'slack'"
+    ];
+    package = pkgs.picom.overrideAttrs (o: {
+      src = pkgs.fetchFromGitHub {
+        repo = "picom";
+        owner = "ibhagwan";
+        rev = "44b4970f70d6b23759a61a2b94d9bfb4351b41b1";
+        sha256 = "0iff4bwpc00xbjad0m000midslgx12aihs33mdvfckr75r114ylh";
+      };
+    });
+  };
+}

--- a/sys/configuration.nix
+++ b/sys/configuration.nix
@@ -2,7 +2,7 @@
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 
-{ config, pkgs, ... }:
+{ inputs, config, pkgs, ... }:
 
 {
   nix = {
@@ -30,6 +30,15 @@
         gtk3Support = true;
       };
     })
+    (self: super: {
+      vscodeInsiders =
+        inputs.vscodeInsiders.packages.${super.system}.vscodeInsiders;
+      firefox-nightly-bin =
+        inputs.flake-firefox-nightly.packages.${super.system}.firefox-nightly-bin;
+    })
+    inputs.powercord-overlay.overlay
+    inputs.nur.overlay
+    inputs.neovim-nightly-overlay.overlay
   ];
 
   imports = [ ./hardware-configuration.nix ];
@@ -105,6 +114,18 @@
     openssh.authorizedKeys.keys = [
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFA12eoS+C+n1Pa1XaygSmx4+CGkO6oYV5bZeSeBU28Y mars@possums.xyz"
     ];
+  };
+
+  home-manager = {
+    # Pass inputs to all home-manager modules
+    # Isn't used currently, but could be useful
+    extraSpecialArgs = { inherit inputs; };
+    # Use packages configured by NixOS configuration (overlays & allowUnfree)
+    useGlobalPackages = true;
+    users.marshall = {
+      imports = [ ../home ];
+      home.stateVersion = "22.05";
+    };
   };
 
   system.activationScripts = {


### PR DESCRIPTION
This also makes the home-manager configuration a part of the NixOS
configuration, which means that you only need to run nixos-rebuild.